### PR TITLE
Serienmail schlägt fehl

### DIFF
--- a/sendsermail.php
+++ b/sendsermail.php
@@ -26,7 +26,7 @@ if ($dateiname) {
     $mime->addAttachment($filedata, $_SESSION["type"],$_SESSION["dateiname"], false );
 }
 
-$sql="select * from tempcsvdata where uid = '".$_SESSION["loginCRM"]."' and id < 1";
+$sql="select * from tempcsvdata where uid = '".$_SESSION["loginCRM"]."' and id < 1 order by id asc";
 $data=$GLOBALS['dbh']->getAll($sql);
 $felder=explode(":",$data[0]["csvdaten"]);
 $pemail=array_search("EMAIL",$felder);


### PR DESCRIPTION
Das Script verlässt sich darauf, dass die Datenbank immer die CSV-Header-Zeile als erstes ausgibt, erzwingt das aber nicht explizit mit "order by". Das kann unter Umständen dazu führen, dass die Mails nicht an die E-Mail-Adressen, sondern an die jeweilige Anrede verschickt werden, was natürlich nicht funktioniert.