### PR TITLE
Bug-Fix: kivitendo-erp 3.5.1 Kompatibilität

### DIFF
--- a/update/add_crm_master_rights.sql
+++ b/update/add_crm_master_rights.sql
@@ -1,7 +1,6 @@
 -- @tag: add_crm_master_rights
 -- @description: Rechte für CRM in die Datenbank migrieren
 -- @depends: release_3_3_0
--- @charset: utf-8
 -- @locales: CRM
 -- @locales: Searchmask
 -- @locales: Add new Addresses


### PR DESCRIPTION
seit commit #1f0d7da266e23a443c47aaa2dbab844e6be50ee4 werden unbekannte Control-Felder als Fehler gewertet.