### PR TITLE
Anfrage optimieren

### DIFF
--- a/ajax/contact.php
+++ b/ajax/contact.php
@@ -13,9 +13,13 @@ function newContact( $data ){
     echo 1;
 }
 
-function getData(){
+function getData($data=False){
+    $where = "";
+    if($data && isset($data['id'])) {
+        $where = " WHERE id = ".$data['id'];
+    }
     //alle Datensätze bereitstellen
-    $rs = $GLOBALS[ 'dbh' ]->getAll( 'SELECT * FROM contact_events', true );
+    $rs = $GLOBALS[ 'dbh' ]->getAll( 'SELECT * FROM contact_events'.$where, true );
     echo $rs;
 }
 

--- a/tpl/firma1.tpl
+++ b/tpl/firma1.tpl
@@ -217,7 +217,7 @@
     function getSingleRow(id) {
         $.ajax({
             dataType: 'json',
-            url: 'ajax/contact.php?action=getData',
+            url: 'ajax/contact.php?action=getData?id='+id,
             method: "GET",
             success: function( json ) {
                 for (var i = 0; i < json.length; i++) {

--- a/tpl/firma1.tpl
+++ b/tpl/firma1.tpl
@@ -217,7 +217,7 @@
     function getSingleRow(id) {
         $.ajax({
             dataType: 'json',
-            url: 'ajax/contact.php?action=getData?id='+id,
+            url: 'ajax/contact.php?action=getData&id='+id,
             method: "GET",
             success: function( json ) {
                 for (var i = 0; i < json.length; i++) {


### PR DESCRIPTION
Das Laden der Daten für einen einzelnen Eintrag aus der "Kontakt" Tabelle beim Kunden/Lieferanden braucht sehr lange bei vielen Einträgen, weil erst alle Daten aus der Tabelle übertragen werden, dafür dass dann am Schluss client-seitig nur ein einziger Eintrag ausgewählt wird.

Durch diesen PR wird die ID des geforderten Eintrags als Parameter an den Server übergeben und dann nur der einzelne Eintrag zurück gegeben. Ist der Parameter nicht angegeben, liefert der Server wie bisher alle Einträge.